### PR TITLE
Постинг картинки, вместо ссылки на нее

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,8 +49,8 @@ def download_image(image_url: str) -> str:
 
     response = requests.get(image_url)
 
-    # Имя файла - случайное число + последние четыре символа URL (расширение файла)
-    filepath = 'images/' + str(random.randint(0, 10**6)) + image_url[-4:]
+    # Имя файла - image + последние четыре символа URL (расширение файла)
+    filepath = 'images/image' + image_url[-4:]
 
     file = open(filepath, "wb")
     file.write(response.content)


### PR DESCRIPTION
Теперь скрипт постит картинку, а не ссылку на нее
Для этого была добавлена функция ```download_image(image_url)```, которая принимает ссылку на файл и сохраняет его в ```images/``` со случайным именем (оно может пересечься с уже существующим и переписать старый файл, но я подумал, что это не так важно)
Потом скрипт загружает картинку на сервера ВК, получает ответ, достает из него необходимые данные и формирует "ВК-ссылку" на файл, который передает в ```attachments``` и, таким образом, картинка прикрепляется как картинка, а не ссылка